### PR TITLE
Revert "bluejay: Re-enable broken dup rules check"

### DIFF
--- a/BoardConfigLineage.mk
+++ b/BoardConfigLineage.mk
@@ -3,3 +3,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+
+BUILD_BROKEN_DUP_RULES := true


### PR DESCRIPTION
This reverts commit 271bff4fb3c1a6973e90511b9169022bb7dfffcc.

duplicate definition of RadioConfigLib.jar in device tree and vendor, which was causing build failure.

disabling the check should help the build proceed, since idk much about how to fix the problem